### PR TITLE
Modify WG-Charter TD to address review issues

### DIFF
--- a/charters/wot-wg-2016.html
+++ b/charters/wot-wg-2016.html
@@ -171,16 +171,68 @@
 
         <h3>Thing Description</h3>
 
-        <p>The Working Group will develop solutions to describe Things through metadata and declarations of their capabilities (e.g., possible interactions). This work includes the definition of different <i>machine-understandable vocabularies</i> based on triples and linkable graphs as well as serialization formats of such a Thing Description. The aim is to be compatible with existing vocabularies and tools (e.g., Linked Open Data, Schema.org, Resource Description Framework (RDF), semantic reasoners, etc.).</p>
-
+        <p>The Working Group will develop solutions to describe Things through metadata and declarations of their capabilities (e.g., possible interactions). 
+           This work includes the definition of different <i>machine-understandable vocabularies</i> based on triples and 
+           linkable graphs as well as serialization formats of such a Thing Description. 
+           The aim is to be compatible with existing vocabularies and tools 
+           (e.g., Linked Open Data, Schema.org, Resource Description Framework (RDF), semantic reasoners, etc.).
+           The Thing Description will be aimed at enabling scalable and automated tooling, including but not limited to search, 
+           automated bridging, service composition, validation, and development abstractions.
+           While the Thing Description will enable the use of powerful semantic tooling, it will be designed in such a way
+           that even constrained devices can use it, if only by generating metadata to be interpreted by more powerful
+           systems.  
+           In particular, the Thing Description standard will provide a sufficiently powerful base vocabulary that
+           it will not be <em>necessary</em> for constrained systems to do RDF or other semantic processing, although we will 
+           enable more powerful systems to do so.
+        </p>
+        <p>The Thing Description will include the following components:</p>
         <ul>
-          <li>A common vocabulary for describing Things in terms of the data and interaction models they expose to applications (e.g., interaction patterns such as Properties, Actions, and Events as described in the <a href="http://w3c.github.io/wot/current-practices/wot-practices.html">WoT Interest Group current practices document</a>). This will cover Thing lifecycles, datatypes (including streams and integrity constraints), and provision for early and late binding. This cross-domain vocabulary will be designed for use in combination with vocabularies for domain-specific semantics and metadata. Consideration will be given to the means for describing the stability of data models and metadata, and how they evolve over time. This is needed to manage interdependencies and is analogous to the role of metadata for package management in the Linux operating system.</li>
+          <li>A common vocabulary for describing Things in terms of the data and interaction models they expose to applications 
+            (e.g., interaction patterns such as Properties, Actions, and Events as described in the 
+            <a href="http://w3c.github.io/wot/current-practices/wot-practices.html">WoT Interest Group current practices document</a>). 
+            This vocabulary will cover Thing lifecycles, 
+            datatypes (including streams and integrity constraints), 
+            and provision for early and late binding. 
+            This cross-domain vocabulary will be designed for use in combination with vocabularies for 
+            domain-specific semantics and metadata. 
+            Consideration will be given to the means for describing the stability of data models and metadata, 
+            and how they evolve over time. 
+            This is needed to manage interdependencies and is analogous to the role of metadata for package management 
+            in the Linux operating system.
+          </li>
 
-          <li>A common vocabulary for security and privacy metadata as a basis for platforms to determine how to securely interoperate. This will build upon emerging standards and best practices for securing exchanges, and includes metadata relating to authentication, authorization, secure communication, and privacy policies. The use of such metadata will be optional (to support deployments that prefer to inform the requester via error responses rather than upfront). It will support, but not mandate, the utilization of online trusted third party services such as authorization servers. It will support a variety of security token form factors of established serialization formats, domain-specific security token contents (e.g., building automation), and various security models. It will support a variety of protocols for their acquisition and for transportation. Support for secure communications will consider transport as well as application-level security.</li>
+          <li>A common vocabulary for security and privacy metadata as a basis for platforms to determine how to 
+            securely interoperate. 
+            This will build upon emerging standards and best practices for securing exchanges, 
+            including metadata relating to authentication, authorization, secure communication, and privacy policies.
+            <!--
+            The use of such metadata will be optional (to support deployments that prefer to inform the requester 
+            via error responses rather than upfront). 
+-->
+            It will support, but not mandate, 
+            the utilization of online trusted third party services such as authorization servers. 
+            It will support a variety of security token form factors of established serialization formats, 
+            domain-specific security token contents (e.g., building automation), and various security models. 
+            It will support a variety of protocols for their acquisition and for transportation. 
+            Support for secure communications will consider transport as well as application-level security.</li>
 
-          <li>A common vocabulary for communications metadata. This will enable platforms to determine how to interoperate given a choice of protocols, data formats, and encodings, as well as different communication patterns, e.g., push, pull, pub-sub, and peer-to-peer. Communications metadata may be needed to describe the multiplexing of data from different sensors, different approaches to buffering data, and the interoperability requirements for communicating with battery- or ambient-powered devices that spend a lot of their time asleep to conserve power.</li>
+          <li>A common vocabulary for communications metadata. 
+            This will enable platforms to determine how to interoperate given a choice of protocols, 
+            data formats, and encodings, as well as different communication patterns, 
+            e.g., push, pull, pub-sub, and peer-to-peer. 
+            Communications metadata may be needed to describe the multiplexing of data from different sensors, 
+            different approaches to buffering data, 
+            and the interoperability requirements for communicating with battery-powered or ambient-powered devices 
+            that spend a lot of their time asleep to conserve power.
+          </li>
 
-          <li>Serialization formats for the Thing Description suitable for processing on resource-constrained platforms and designed to appeal to application developers. The encoding shall allow for resource-efficient instantiation of the software objects that reflect the data and interaction models of Things. Where practical, this will be based upon existing formats and encodings (e.g., EXI- or CBOR-compressed JSON-LD).</li>
+          <li>Serialization formats for the Thing Description suitable for use by resource-constrained platforms
+            will be provided
+            and designed to appeal to application developers. 
+            The encoding shall allow for resource-efficient instantiation of the software objects that 
+            reflect the data and interaction models of Things. 
+            Where practical, 
+            this will be based upon existing formats and encodings (e.g., EXI- or CBOR-compressed JSON-LD).</li>
         </ul>
 
         <h3>Scripting APIs</h3>


### PR DESCRIPTION
Modifications to description of TD deliverable in WG charter to address issues raised by reviewers:
- Emphasis on enabling tooling
- Note that it will be designed in such a way that even constrained devices can "use" it (don't know if we want to be more specific; I'm thinking constrained devices would not need to parse the TD, but would be able to generate data in the TD form).   Tried to add a few more sentences to clarify this issue
- Took out the "The use of such metadata will be optional..." comment in security and privacy section.   I think that needs to be decided based on technical merit, not in the charter.
- I changed "processing on resource-constrained devices" to "use by resource-constrained devices".   Such devices may "use" metadata by generating it, but may not themselves parse it or try to manipulate it ("processing" implies parsing in my view).