### PR TITLE
Incorporate Sebastian's feedback

### DIFF
--- a/charters/wot-wg-2016.html
+++ b/charters/wot-wg-2016.html
@@ -173,8 +173,8 @@
 
         <p>The Working Group will develop solutions to describe Things through metadata and declarations of their capabilities 
            (e.g., possible interactions). 
-           This work includes the definition of different <i>machine-understandable vocabularies</i> based on triples and 
-           linkable graphs as well as serialization formats of such a Thing Description. 
+           This work includes the definition of different <i>machine-understandable vocabulary sets</i>
+           as well as serialization formats of such a Thing Description. 
            The Thing Description will be aimed at enabling scalable and automated tooling, including but not limited to search, 
            automated bridging, service composition, validation, and development abstractions.
            While enabling the use of powerful tooling, the Thing Description will be designed in such a way
@@ -187,7 +187,8 @@
         </p>
         <p>The Thing Description will include the following components:</p>
         <ul>
-          <li>A common vocabulary for describing Things in terms of the data and interaction models they expose to applications 
+          <li>A common vocabulary for describing Things in terms of the data and interaction models they 
+            expose to and/or consume from applications 
             (e.g., interaction patterns such as Properties, Actions, and Events as described in the 
             <a href="http://w3c.github.io/wot/current-practices/wot-practices.html">WoT Interest Group current practices document</a>). 
             This vocabulary will cover Thing lifecycles, 
@@ -195,10 +196,6 @@
             and provision for early and late binding. 
             This cross-domain vocabulary will be designed for use in combination with vocabularies for 
             domain-specific semantics and metadata. 
-            Consideration will be given to the means for describing the stability of data models and metadata, 
-            and how they evolve over time. 
-            This is needed to manage interdependencies and is analogous to the role of metadata for package management 
-            in the Linux operating system.
           </li>
 
           <li>A common vocabulary for security and privacy metadata as a basis for platforms to determine how to 


### PR DESCRIPTION
- remove mention of triples and linked data in intro sentence (too much detail)
- expose to -> expose to and/or consume from
- remove "Consideration will be given to.... Linux operating system" as unnecessary detail