### PR TITLE
Update to collaborations in WG Charter

### DIFF
--- a/charters/wot-wg-2016.html
+++ b/charters/wot-wg-2016.html
@@ -478,16 +478,36 @@
       <section id="coordination">
         <h2>Coordination</h2>
 
-        <p>For all specifications, this Working Group will seek <a href="https://www.w3.org/Guide/Charter.html#horizontal-review">horizontal review</a> for accessibility, internationalization, performance, privacy, and security with the relevant Working and Interest Groups, and with the <a href="https://www.w3.org/2001/tag/" title="Technical Architecture Group">TAG</a>. Invitation for review must be issued during each major standards-track document transition, including <a href="https://www.w3.org/2015/Process-20150901/#RecsWD" title="First Public Working Draft">FPWD</a> and <a href="https://www.w3.org/2015/Process-20150901/#RecsCR" title="Candidate Recommendation">CR</a>, and should be issued when major changes occur in a specification.</p>
+        <p>For all specifications, 
+          this Working Group will seek 
+          <a href="https://www.w3.org/Guide/Charter.html#horizontal-review">horizontal review</a> 
+          for 
+          accessibility, 
+          internationalization, 
+          performance, 
+          privacy, 
+          and security 
+          with the relevant Working and Interest Groups, 
+          and with the <a href="https://www.w3.org/2001/tag/" title="Technical Architecture Group">TAG</a>. 
+          Invitation for review must be issued during each major standards-track document transition, 
+          including <a href="https://www.w3.org/2015/Process-20150901/#RecsWD" title="First Public Working Draft">FPWD</a> 
+          and 
+          <a href="https://www.w3.org/2015/Process-20150901/#RecsCR" title="Candidate Recommendation">CR</a>, 
+          and should be issued when major changes occur in a specification.</p>
 
-        <p>Additional technical coordination with the following Groups will be made, per the <a href="https://www.w3.org/2015/Process-20150901/#WGCharter">W3C Process Document</a>:</p>
-
-        <div>
-          <h3 id="w3c-coordination">W3C Groups</h3>
-
+        <h3 id="w3c-coordination">W3C Groups</h3>
+        <p>Additional technical coordination with the following W3C Groups will be made, 
+          per the <a href="https://www.w3.org/2015/Process-20150901/#WGCharter">W3C Process Document</a>:</p>
           <dl>
             <dt><a href="https://www.w3.org/WoT/IG/">Web of Things Interest Group</a></dt>
-            <dd>The Web of Things Interest Group provides a forum for discussion of use cases and requirements, for investigation of areas that need further study before transfer to the standardization track, and for outreach and collaboration with industry alliances and standards development organizations. The Web of Things Working Group may ask the Interest Group to look into issues that are found to be insufficiently mature for immediate standardization, The Interest Group will take the lead on work on testing, e.g., organization of PlugFest events, test frameworks, and joint work with other organizations on interoperability testing.</dd>
+            <dd>The Web of Things Interest Group provides a forum for discussion of use cases and requirements, 
+                for investigation of areas that need further study before transfer to the standardization track, 
+                and for outreach and collaboration with industry alliances and standards development organizations. 
+                The Web of Things Working Group may ask the Interest Group to look into issues that are found to be 
+                insufficiently mature for immediate standardization.
+                The Interest Group will take the lead on work on testing, 
+                e.g., organization of PlugFest events, test frameworks, 
+                and joint work with other organizations on interoperability testing.</dd>
             <dt><a href="http://www.w3.org/2009/dap/">Device and Sensors Working Group</a></dt>
             <dd>For coordination on APIs for sensors and actuators.</dd>
             <dt><a href="http://www.w3.org/XML/EXI/">Efficient XML Interchange Working Group</a></dt>
@@ -498,24 +518,29 @@
             <dd>For collaboration on technologies and requirements relating to connected cars and the Web of Things.</dd>
           </dl>
           
-          <h3 id="external-coordination">External Organizations</h3>
-          
+        <h3 id="external-coordination">External Organizations</h3>
+          <p>Additional technical coordination with the following external organizations will be sought, 
+          per the <a href="https://www.w3.org/2015/Process-20150901/#WGCharter">W3C Process Document</a>.
+          This list is not meant to exclude additional technical coordination with other external organizations not
+          on this list, if such coordination is determined to be relevant by this Working Group.
+        </p>
           <dl>
             <dt><a href="https://datatracker.ietf.org/wg/ace/charter/">IETF Authentication and Authorization for Constrained Environments (ace) Working Group</a></dt>
             <dd>In respect to security building blocks for the Web of Things.</dd>
             <dt><a href="https://datatracker.ietf.org/doc/charter-ietf-core/">IETF Core Working Group</a></dt>
             <dd>In respect to protocol bindings for the CoAP protocol.</dd>
             <dt><a href="http://www.onem2m.org">OneM2M</a></dt>
-            <dd>For collaboration on integrating M2M based platforms within the Web of Things, including platform metadata and approaches for enabling semantic interoperability, and end to end security across platforms.</dd>
+            <dd>For collaboration on integrating M2M based platforms within the Web of Things, 
+                including platform metadata and approaches for enabling semantic interoperability, 
+                and end to end security across platforms.</dd>
             <dt><a href="https://opcfoundation.org">OPC Foundation</a></dt>
             <dd>For collaboration on semantic interoperability and end to end security across platforms.</dd>
             <dt><a href="http://openconnectivity.org">Open Connectivity Foundation</a></dt>
-            <dd>For collaboration on integrating OCF based platforms within the Web of Things, including platform metadata and approaches for enabling semantic interoperability, and end to end security across platforms.</dd>
+            <dd>For collaboration on integrating OCF based platforms within the Web of Things, 
+              including platform metadata and approaches for enabling semantic interoperability, 
+              and end to end security across platforms.</dd>
           </dl>
-        </div>
       </section>
-
-
 
       <section class="participation">
         <h2 id="participation">Participation</h2>


### PR DESCRIPTION
Formatting changes (line breaks Knuth style) to make diffs clearer.
Change wording around external organizations to include "sought" (since we can't force external organizations to coordinate with us) and reorganize sections.   Make list of external orgs non-exclusive.